### PR TITLE
feat: add draft gene essentiality instructions

### DIFF
--- a/mkdocs/docs/gene_essentiality.md
+++ b/mkdocs/docs/gene_essentiality.md
@@ -1,0 +1,59 @@
+# Gene essentiality with DepMap
+
+!!! warning
+    The writing of these instructions is a work in progress, originality created through the pull request https://github.com/SysBioChalmers/Human-GEM/pull/574/. The instructions are not guaranteed to work, and assume background knowledge.
+
+## Setup
+
+First make sure you have the DepMap.org data - we currently use DepMap version 2021Q3. You need to go to the downloads section at [DepMap](https://depmap.org/portal/download/all/), select `21Q3`.
+
+Move into `Human-GEM/code/DepMapGeneEss/data` the following downloaded files:
+
+- `Achilles_gene_effect.csv`
+- `CCLE_expression_full.csv`
+
+## Data wrangling
+
+1. Open the script `ConvertGeneEssInputData.R` in RStudio and run it. This will generate the file `DepMap_tpm_gene_symbols.txt`.
+2. Run `PrepDepMapData.m`. This will take an hour or so and generates the files:
+    - `arrayDataDepMap.mat`
+    - `prepDataGeneSymbols.mat`
+
+
+## Cluster computation
+
+### Configure dependencies
+
+1. Create a folder on the cluster with a suitable name, for example `GeneEssDepMap`. Within that folder, create a folder named `components`.
+2. Copy RAVEN, COBRA, and Human-GEM to `components` - they need to reside under those exact names, because those and underlying folders will be added to the Matlab path.
+3. Make sure the Human-GEM folder `Human-GEM/code/DepMapGeneEss/data` is copied as well with the files generated above under _Setup_.
+4. Create a folder `DepMapRuns` in the top folder `GeneEssDepMap`. Copy in this new folder the files:
+    - `run_gen_depmap_models.sh`
+    - `run_evaless_depmap.sh`
+    - `generate_DepMap_models_ftINIT_Cluster.m`
+    - `getTaskEssentialGenesCluster.m`
+
+Also create a folder called `logs` in the same folder.
+
+### Run cluster jobs
+
+1. Make sure you are in the `DepMapRuns` folder. First, generate the models using the following line (also available in the .sh script):
+
+```bash
+sbatch -o logs/run_gen_depmap_models-%A-%a.log --array=1-40 run_gen_depmap_models.sh
+```
+
+It may be needed to inititialize the RAVEN, COBRA and GECKO toolboxes first. Each of these has their own installation command. Also remember to choose the solver for the RAVEN toolbox.
+
+2. After the model generation has completed, run:
+
+```bash
+sbatch -o logs/run_evaless_depmap-%A-%a.log --array=1-40 run_evaless_depmap.sh
+```
+
+3. Download all produced files to the data folder on your computer. These are found in `components/Human-GEM/code/DepMapGeneEss/data`.
+
+4. Run `evaluateDepMapEssentialityPredictions.m`. Note that you may need to change the folder in the file and that there are some things in the file that need to be modified to match what you want to do. The file currently only gets stats for one model version, but can easily be expanded to take in data from more model versions, although these also need to be processed as above as well.
+
+5. Run `PlotGeneEss.R` in RStudio to make a violin plot of MCC for each model. The code needs some modification to fix paths and 
+number of models.

--- a/mkdocs/docs/gene_essentiality.md
+++ b/mkdocs/docs/gene_essentiality.md
@@ -55,5 +55,4 @@ sbatch -o logs/run_evaless_depmap-%A-%a.log --array=1-40 run_evaless_depmap.sh
 
 4. Run `evaluateDepMapEssentialityPredictions.m`. Note that you may need to change the folder in the file and that there are some things in the file that need to be modified to match what you want to do. The file currently only gets stats for one model version, but can easily be expanded to take in data from more model versions, although these also need to be processed as above as well.
 
-5. Run `PlotGeneEss.R` in RStudio to make a violin plot of MCC for each model. The code needs some modification to fix paths and 
-number of models.
+5. Run `PlotGeneEss.R` in RStudio to make a violin plot of MCC for each model. The code needs some modification to fix paths and number of models.

--- a/mkdocs/docs/index.md
+++ b/mkdocs/docs/index.md
@@ -1,7 +1,7 @@
 # Human-GEM User Guide
 
 !!! important
-    This guide applies to Human-GEM version [v1.12.0](https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.12.0). If you are using a different version of Human-GEM, we cannot guarantee that it will function as described in this guide.
+This guide applies to Human-GEM version [v1.12.0](https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.12.0). If you are using a different version of Human-GEM, we cannot guarantee that it will function as described in this guide.
 
 ## Overview
 
@@ -13,18 +13,16 @@ This guide contains instructions and examples of how to use [Human-GEM](https://
 - [GEM extraction using ftINIT](gem_extraction.md)
 - [GEM comparison](gem_comparison.md)
 - [GEM extraction from single-cell RNA-Seq data](gem_extraction_sc.md)
+- [Gene essentiality with DepMap](gene_essentiality.md)
 - [Additional tools](additional_tools.md)
 - [FAQs and troubleshooting](faq_troubleshoot.md)
 - [Contact](contact.md)
-
 
 ## Citation
 
 > J. L. Robinson, et al. An atlas of human metabolism. _Sci. Signal._ 13, eaaz1482 (2020). [doi:10.1126/scisignal.aaz1482](https://doi.org/10.1126/scisignal.aaz1482)
 
-
 <br/><br/>
 
 [![SysBio](img/sysbio_logo.png){: style="width:200px"}](https://www.sysbio.se/) &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 [![Metabolic Atlas](img/metabolic_atlas_logo.svg){: style="width:200px"}](https://www.metabolicatlas.org/)
-

--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -7,6 +7,7 @@ nav:
   - GEM extraction using ftINIT: gem_extraction.md
   - GEM comparison: gem_comparison.md
   - GEM extraction from scRNA-Seq data: gem_extraction_sc.md
+  - Gene essentiality with DepMap: gene_essentiality.md
   - Additional tools: additional_tools.md
   - FAQs and troubleshooting: faq_troubleshoot.md
   - Contact: contact.md


### PR DESCRIPTION
This PR aims to move the documentation of running gene essentiality with DepMap data, originated in Human-GEM as [`Instructions.txt`](https://github.com/SysBioChalmers/Human-GEM/blob/3340aaa2f97b79cea85a9187deddfae02d6e682f/code/DepMapGeneEss/Instructions.txt) through the pull request https://github.com/SysBioChalmers/Human-GEM/pull/574, into the online guide.